### PR TITLE
Fix for race condition by loading text only after the editor has been loaded

### DIFF
--- a/cupcake/texteditor/__init__.py
+++ b/cupcake/texteditor/__init__.py
@@ -1,3 +1,4 @@
+import os
 import tkinter as tk
 
 from ..utils import Scrollbar
@@ -35,6 +36,9 @@ class TextEditor(BaseEditor):
 
         self.text.bind("<<Change>>", self.on_change)
         self.text.bind("<<Scroll>>", self.on_scroll)
+
+        if self.path and os.path.isfile(self.path):
+            self.text.load_file()
 
     def on_change(self, *_):
         self.text.refresh()

--- a/cupcake/texteditor/text.py
+++ b/cupcake/texteditor/text.py
@@ -1,4 +1,4 @@
-import re, codecs, os
+import re, codecs
 import threading, queue
 import tkinter as tk
 from collections import deque
@@ -22,9 +22,6 @@ class Text(Text):
         self.bom = True
         self.current_word = None
         self.words = []
-
-        if self.path and os.path.isfile(self.path):
-            self.load_file()
 
         self.syntax = Syntax(self)
         self.auto_completion = AutoComplete(


### PR DESCRIPTION
Hi

When running cupcake on my machine I was intermittently getting this error:

```bash
Traceback (most recent call last):
  File "/Users/sean/Documents/PycharmProjects/cupcake/cupcake/texteditor/text.py", line 294, in load_file
    self.process_queue()
  File "/Users/sean/Documents/PycharmProjects/cupcake/cupcake/texteditor/text.py", line 317, in process_queue
    self.master.on_scroll()
  File "/Users/sean/Documents/PycharmProjects/cupcake/cupcake/texteditor/__init__.py", line 46, in on_scroll
    self.linenumbers.redraw()
    ^^^^^^^^^^^^^^^^
AttributeError: 'TextEditor' object has no attribute 'linenumbers'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/sean/Documents/PycharmProjects/cupcake/examples/basic.py", line 20, in <module>
    e = Editor(root, __file__)
        ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sean/Documents/PycharmProjects/cupcake/cupcake/__init__.py", line 99, in __init__
    self.content = get_editor(self, path, path2, diff, language)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sean/Documents/PycharmProjects/cupcake/cupcake/__init__.py", line 29, in get_editor
    return TextEditor(base, path, language=language)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sean/Documents/PycharmProjects/cupcake/cupcake/texteditor/__init__.py", line 21, in __init__
    self.text = Text(self, path=self.path, minimalist=minimalist, language=language)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sean/Documents/PycharmProjects/cupcake/cupcake/texteditor/text.py", line 27, in __init__
    self.load_file()
  File "/Users/sean/Documents/PycharmProjects/cupcake/cupcake/texteditor/text.py", line 296, in load_file
    self.master.unsupported_file()
  File "/Users/sean/Documents/PycharmProjects/cupcake/cupcake/texteditor/__init__.py", line 51, in unsupported_file
    self.text.highlighter.lexer = None
    ^^^^^^^^^
AttributeError: 'TextEditor' object has no attribute 'text'
```

I believe this is due to a race condition where a thread is spawned to load the text into the editor before the editor has been fully loaded. This attempts to fix that by moving the load operation into the end of the TextEditor class.

My os information

macOS Ventura
Version 13.4.1 (22F82)
Chip: Apple M2 Pro
Python 3.11.4